### PR TITLE
Refactor(keamanan): Use academic year (th_ajaran_h) from API

### DIFF
--- a/src/pages/keamanan/indisipliner/part/IndisiplinerRiwayat.vue
+++ b/src/pages/keamanan/indisipliner/part/IndisiplinerRiwayat.vue
@@ -48,7 +48,7 @@
 												m2hFormat(indisipliner.tgl_sidang)
 											}}
 											<q-space />
-											{{ hijriToThAjaranH(m2h(indisipliner.tgl_sidang)) }}
+											{{ indisipliner.th_ajaran_h }}
 										</td>
 									</tr>
 
@@ -99,8 +99,7 @@
 </template>
 <script setup>
 import { formatDateShort } from 'src/utils/format-date';
-import { m2h, m2hFormat } from 'src/utils/hijri';
-import { hijriToThAjaranH } from 'src/utils/tahun-ajaran';
+import { m2hFormat } from 'src/utils/hijri';
 import { onMounted, onUpdated, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import IndisiplinerForm from 'src/components/forms/IndisiplinerForm.vue';

--- a/src/pages/keamanan/perizinan/part/IzinRiwayat.vue
+++ b/src/pages/keamanan/perizinan/part/IzinRiwayat.vue
@@ -44,7 +44,7 @@
 										<td class="flex">
 											{{ formatDateShort(izin.dari_tgl) + ' | ' + m2hFormat(izin.dari_tgl) }}
 											<q-space />
-											{{ hijriToThAjaranH(m2h(izin.dari_tgl)) }}
+											{{ izin.th_ajaran_h }}
 										</td>
 									</tr>
 
@@ -103,8 +103,7 @@
 </template>
 <script setup>
 import { formatDateShort } from 'src/utils/format-date';
-import { m2h, m2hFormat } from 'src/utils/hijri';
-import { hijriToThAjaranH } from 'src/utils/tahun-ajaran';
+import { m2hFormat } from 'src/utils/hijri';
 import { onMounted, onUpdated, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import IzinPesantrenForm from 'src/components/forms/IzinPesantrenForm.vue';


### PR DESCRIPTION
Simplify the display of the Hijri academic year in the disciplinary (`IndisiplinerRiwayat`) and permission (`IzinRiwayat`) history components.

Instead of calculating the academic year on the client-side using `hijriToThAjaranH(m2h(...))`, the components now render the `th_ajaran_h` property directly from the data object. This refactoring removes redundant client-side computations and cleans up unused utility imports.